### PR TITLE
Fix: infinite scroll stopping working before post list ends

### DIFF
--- a/src/components/pages/TimelinePage/index.jsx
+++ b/src/components/pages/TimelinePage/index.jsx
@@ -112,7 +112,7 @@ export default function TimelinePage() {
       data-testid="episodes-infinite-scroll"
       pageStart={0}
       loadMore={getMorePosts}
-      hasMore={hasNextPage && !loadingNewPosts}
+      hasMore={!loadingNewPosts}
       loader={<ThreeDots width={30} height={10} color={"#fff"} />}
     >
       <PostsList posts={posts}></PostsList>


### PR DESCRIPTION
O infinite scroll nao tava puxando mais os posts mesmo que nao tenha chegado no fim da lista (mudei o atributo hasMore do InfiniteScroll, resolveu esse problema mas talvez tenha quebrado outra coisa)